### PR TITLE
[Fix] Added new niconico api

### DIFF
--- a/extension/background/niconico.js
+++ b/extension/background/niconico.js
@@ -2,8 +2,7 @@
 
   const getPageTitle = async tabId => (await browser.tabs.get(tabId)).title;
   window.onRequest([
-    '*://nmsg.nicovideo.jp/api.json/',
-    '*://nvcomment.nicovideo.jp/legacy/api.json',
+    '*://nvcomment.nicovideo.jp/v1/threads',
   ], async function (response, pageContext, { url }) {
     const { thread, danmaku } = window.danmaku.parser.niconico(response);
     if (danmaku.length === 0) return;

--- a/extension/background/niconico.js
+++ b/extension/background/niconico.js
@@ -2,6 +2,8 @@
 
   const getPageTitle = async tabId => (await browser.tabs.get(tabId)).title;
   window.onRequest([
+    '*://nmsg.nicovideo.jp/api.json/',
+    '*://nvcomment.nicovideo.jp/legacy/api.json',
     '*://nvcomment.nicovideo.jp/v1/threads',
   ], async function (response, pageContext, { url }) {
     const { thread, danmaku } = window.danmaku.parser.niconico(response);

--- a/extension/danmaku/parser.js
+++ b/extension/danmaku/parser.js
@@ -288,7 +288,7 @@
       mainJson.data.threads.forEach(thread => {
         list = list.concat(thread.comments);
       });
-      const { thread } = "comments";
+      const thread = mainJson.data.globalComments[0].id;
       const danmaku = list.map(comment => {
         if (!comment.body || !(comment.vposMs >= 0) || !comment.no) return null;
         const { vposMs, commands, body, no } = comment;

--- a/extension/danmaku/parser.js
+++ b/extension/danmaku/parser.js
@@ -283,18 +283,22 @@
      */
     parser.niconico = function (content) {
       const text = typeof content === 'string' ? content : new TextDecoder('utf-8').decode(content);
-      const data = JSON.parse(text);
-      const list = data.map(item => item.chat).filter(x => x);
-      const { thread } = list.find(comment => comment.thread);
+      const mainJson = JSON.parse(text);
+      var list = [];
+      mainJson.data.threads.forEach(thread => {
+        list = list.concat(thread.comments);
+      });
+      const { thread } = "comments";
       const danmaku = list.map(comment => {
-        if (!comment.content || !(comment.vpos >= 0) || !comment.no) return null;
-        const { vpos, mail = '', content, no } = comment;
+        if (!comment.body || !(comment.vposMs >= 0) || !comment.no) return null;
+        const { vposMs, commands, body, no } = comment;
+        const commandString = commands.join(' ');
         return {
-          text: content,
-          time: vpos / 100,
-          color: parseNiconicoColor(mail),
-          mode: parseNiconicoMode(mail),
-          size: parseNiconicoSize(mail),
+          text: body,
+          time: vposMs / 1000,
+          color: parseNiconicoColor(commandString),
+          mode: parseNiconicoMode(commandString),
+          size: parseNiconicoSize(commandString),
           bottom: false,
           id: no,
         };


### PR DESCRIPTION
niconico seems to have changed their api yet again.
Details here: https://zenn.dev/negima1072/articles/nvcomment-api

This pull request changed the niconico parser to the new system, fixing the currently broken extension.

While the previous two api(s) are still there, they shouldn't work anymore due how different the new system is.

Fix was aided by @racendol .