### PR TITLE
Fix Bahamut comment

### DIFF
--- a/extension/background/bahamut.js
+++ b/extension/background/bahamut.js
@@ -4,7 +4,6 @@
   const redirector = (url) => {
     const newUrl = new URL(url);
     newUrl.searchParams.delete('limit');
-    console.log('newUrl=' + newUrl);
     return newUrl.href;
   };
 

--- a/extension/background/bahamut.js
+++ b/extension/background/bahamut.js
@@ -1,11 +1,22 @@
 ; (function () {
 
   const getPageTitle = async tabId => (await browser.tabs.get(tabId)).title.replace(/ - \S*$/, '');
+  const redirector = (url) => {
+    const newUrl = new URL(url);
+    newUrl.searchParams.delete('limit');
+    console.log('newUrl=' + newUrl);
+    return newUrl.href;
+  };
+
+  window.redirect([
+    'https://api.gamer.com.tw/anime/v1/danmu.php?*limit=*',
+  ], { redirector: redirector });
 
   window.onRequest([
-    'https://api.gamer.com.tw/anime/v1/danmu.php',
+    'https://api.gamer.com.tw/anime/v1/danmu.php?*',
   ], async function (response, pageContext, { url, requestBody }) {
-    const { sn } = requestBody.formData;
+    const params = new URL(url).searchParams;
+    const sn = params.get('videoSn');
     const { danmaku } = window.danmaku.parser.bahamut(response);
     if (danmaku.length === 0) return;
     const { tabId } = pageContext;

--- a/extension/background/bahamut.js
+++ b/extension/background/bahamut.js
@@ -3,7 +3,7 @@
   const getPageTitle = async tabId => (await browser.tabs.get(tabId)).title.replace(/ - \S*$/, '');
 
   window.onRequest([
-    'https://ani.gamer.com.tw/ajax/danmuGet.php',
+    'https://api.gamer.com.tw/anime/v1/danmu.php',
   ], async function (response, pageContext, { url, requestBody }) {
     const { sn } = requestBody.formData;
     const { danmaku } = window.danmaku.parser.bahamut(response);

--- a/extension/background/main.js
+++ b/extension/background/main.js
@@ -80,6 +80,13 @@
     }, { urls: match }, ['blocking'].concat(includeRequestBody ? ['requestBody'] : []));
   };
 
+  const redirect = function(match, { redirector = url => url } = {}) {
+    browser.webRequest.onBeforeRequest.addListener(details => {
+      const { url } = details;
+      return { redirectUrl: redirector(url) };
+    }, { urls: match }, ['blocking']);
+  };
+
   const hidePageAction = tabId => {
     browser.tabs.get(tabId).then(() => {
       browser.pageAction.hide(tabId);
@@ -150,7 +157,6 @@
   });
 
   window.onRequest = onRequest;
-
+  window.redirect = redirect;
 
 }());
-

--- a/extension/danmaku/parser.js
+++ b/extension/danmaku/parser.js
@@ -332,7 +332,7 @@
     parser.bahamut = function (content) {
       const text = typeof content === 'string' ? content : new TextDecoder('utf-8').decode(content);
       const list = JSON.parse(text);
-      const danmaku = list.map(comment => {
+      const danmaku = list.data.danmu.map(comment => {
         if (!comment) return null;
         const { text, time, color, position, size } = comment;
         if (!text) return null;


### PR DESCRIPTION
Changelist
* Updated Bahamut danmaku URL and `videoSn`
* Removed `limit=` query parameter from danmaku request by default
* Fix parser to align with new danmaku JSON structure

There may be a more concise way to fetch the full list of danmaku instead of using `webRequest.BlockingResponse.redirectUrl`. Please feel free to modify my current solution.